### PR TITLE
Add FARM framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ This repository contains a hand-curated of great machine (deep) learning resourc
 6. [pingpong-ai/xlnet-pytorch](https://github.com/pingpong-ai/xlnet-pytorch) - A Pytorch implementation of Google Brain XLNet.
 7. [facebook/fairseq](https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md) - RoBERTa: A Robustly Optimized BERT Pretraining Approach by Facebook AI Research. SoTA results on GLUE, SQuAD and RACE.
 8. [NVIDIA/Megatron-LM](https://github.com/NVIDIA/Megatron-LM) - Ongoing research training transformer language models at scale, including: BERT.
+9. [deepset-ai/FARM](https://github.com/deepset-ai/FARM) - Simple & flexible transfer learning for the industry
 
 ### Keras
 


### PR DESCRIPTION
Building upon the transformers repo, FARM is a home for all species of pretrained language models (e.g. BERT) that can be adapted to different domain languages or down-stream tasks. Standardized interfaces for language models and prediction heads allow easy application for practitioners and fast iteration of experiments. Additional experiment tracking and visualizations support you along the way to have a fast proof-of-concept.